### PR TITLE
Implement HikariCP and Use try with resources for database connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,5 +97,11 @@
             <artifactId>jedis</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/fr/robot/robottags/data/stock/MySQL.java
+++ b/src/main/java/fr/robot/robottags/data/stock/MySQL.java
@@ -1,43 +1,56 @@
 package fr.robot.robottags.data.stock;
 
+import com.zaxxer.hikari.HikariDataSource;
 import fr.robot.robottags.data.AbstractData;
 import fr.robot.robottags.manager.ConfigManager;
-import fr.robot.robottags.manager.StorageManager;
-import fr.robot.robottags.utility.TaskAPI;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.UUID;
 
 import static fr.robot.robottags.Main.log;
 
 public class MySQL implements AbstractData {
 
-    private Connection connection;
-
-    public boolean isConnected() {
-        return connection != null;
-    }
+    HikariDataSource dataSource;
 
     @Override
     public void load() {
-        try {
-            log("&fTrying to connect to the database...");
-            connect();
-            createTable();
-            log("&aSuccessfully connected !");
-        } catch (ClassNotFoundException | SQLException e) {
-            log("&cAn error occurred while trying to connect to the database.");
-            log("&cPlease check your MySQL credentials in the configuration file.");
-            log("&cSwitching to YML storage mode by default.");
-            StorageManager.setMode(StorageManager.DbMode.YML);
+        connect();
+        createTable();
+        log("&aSuccessfully connected to database.");
+    }
+
+    public void connect() {
+        dataSource = new HikariDataSource();
+        dataSource.setMaximumPoolSize(5);
+        dataSource.setJdbcUrl("jdbc:mysql://" +
+                ConfigManager.getConfig().get().getString("storage.mysql-credentials.host") + ":" +
+                ConfigManager.getConfig().get().getString("storage.mysql-credentials.port") + "/" +
+                ConfigManager.getConfig().get().getString("storage.mysql-credentials.database"));
+        dataSource.addDataSourceProperty("user", ConfigManager.getConfig().get().getString("storage.mysql-credentials.username"));
+        dataSource.addDataSourceProperty("password", ConfigManager.getConfig().get().getString("storage.mysql-credentials.password"));
+        dataSource.addDataSourceProperty("useSSL", ConfigManager.getConfig().get().getBoolean("storage.mysql-credentials.useSSL"));
+    }
+
+    public void createTable() {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement("CREATE TABLE IF NOT EXISTS robottags_tags (UUID VARCHAR(100),TAG VARCHAR(100),PRIMARY KEY (UUID))")) {
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
         }
     }
 
     @Override
-    public void close() {
-        if(isConnected()) {
-            try {
-                getConnection().close();
+    public void initPlayer(UUID playerUUID) {
+        if (!hasTag(playerUUID)) {
+            try (Connection connection = dataSource.getConnection(); PreparedStatement ps = connection.prepareStatement("INSERT IGNORE INTO robottags_tags"
+                    + " (UUID) VALUES (?)")) {
+                ps.setString(1, playerUUID.toString());
+                ps.executeUpdate();
             } catch (SQLException e) {
                 e.printStackTrace();
             }
@@ -45,14 +58,27 @@ public class MySQL implements AbstractData {
     }
 
     @Override
-    public void initPlayer(UUID playerUUID) {
-        try {
-            if (!hasTag(playerUUID)) {
-                PreparedStatement ps2 = getConnection().prepareStatement("INSERT IGNORE INTO robottags_tags"
-                        + " (UUID) VALUES (?)");
-                ps2.setString(1, playerUUID.toString());
-                ps2.executeUpdate();
+    public String getTagId(UUID playerUUID) {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement("SELECT TAG FROM robottags_tags WHERE UUID=?")) {
+            ps.setString(1, playerUUID.toString());
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getString("TAG");
             }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public void setTagId(UUID playerUUID, String tag) {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement("UPDATE robottags_tags SET TAG = ? WHERE UUID = ?")) {
+            ps.setString(1, tag);
+            ps.setString(2, playerUUID.toString());
+            ps.executeUpdate();
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -60,8 +86,8 @@ public class MySQL implements AbstractData {
 
     @Override
     public boolean hasTag(UUID playerUUID) {
-        try {
-            PreparedStatement ps = getConnection().prepareStatement("SELECT * FROM  robottags_tags WHERE UUID=?");
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement("SELECT * FROM  robottags_tags WHERE UUID=?")) {
             ps.setString(1, playerUUID.toString());
             ResultSet results = ps.executeQuery();
             return results.next();
@@ -72,85 +98,7 @@ public class MySQL implements AbstractData {
     }
 
     @Override
-    public void setTagId(UUID playerUUID, String tag) {
-        try {
-            PreparedStatement ps = getConnection().prepareStatement("UPDATE robottags_tags SET TAG = ? WHERE UUID = ?");
-            ps.setString(1, tag);
-            ps.setString(2, playerUUID.toString());
-            ps.executeUpdate();
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
-    }
-
-    @Override
-    public String getTagId(UUID playerUUID) {
-        try {
-            PreparedStatement ps = getConnection().prepareStatement("SELECT TAG FROM robottags_tags WHERE UUID=?");
-            ps.setString(1, playerUUID.toString());
-            ResultSet rs = ps.executeQuery();
-            if(rs.next())
-                return rs.getString("TAG");
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-    public void connect() throws ClassNotFoundException, SQLException {
-        if(!isConnected()) {
-            String host = ConfigManager.getConfig().get().getString("storage.mysql-credentials.host");
-            String port = ConfigManager.getConfig().get().getString("storage.mysql-credentials.port");
-            String database = ConfigManager.getConfig().get().getString("storage.mysql-credentials.database");
-            String username = ConfigManager.getConfig().get().getString("storage.mysql-credentials.username");
-            String password = ConfigManager.getConfig().get().getString("storage.mysql-credentials.password");
-
-            String ssl = String.valueOf(ConfigManager.getConfig().get().getBoolean("storage.mysql-credentials.useSSL"));
-            String autoReconnectStr = ConfigManager.getConfig().get().getString("storage.mysql.auto-reconnect");
-            boolean autoReconnect = autoReconnectStr == null || Boolean.parseBoolean(autoReconnectStr);
-
-            connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database +
-                    "?useSSL=" + ssl +
-                    "?autoReconnect=" + autoReconnect,
-                    username, password);
-        }
-    }
-
-    public void disconnect() {
-        if(isConnected()) {
-            try {
-                connection.close();
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    public Connection getConnection() {
-        return connection;
-    }
-
-    public void createTable() {
-        PreparedStatement ps;
-        try {
-            ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS robottags_tags (UUID VARCHAR(100),TAG VARCHAR(100),PRIMARY KEY (UUID))");
-            ps.executeUpdate();
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
-    }
-
-    public void autoReconnect() {
-        Long delay = 20 * 60 * 30L; //30 minutes
-        TaskAPI.runTaskTimer(() -> {
-
-            try {
-                disconnect();
-                connect();
-            } catch (ClassNotFoundException | SQLException e) {
-                log("&cAn error occurred during the auto-reconnection:" + e.getMessage());
-            }
-
-        }, delay, delay);
+    public void close() {
+        dataSource.close();
     }
 }

--- a/src/main/resources/configuration.yml
+++ b/src/main/resources/configuration.yml
@@ -20,7 +20,6 @@ storage:
 
     #Options
     useSSL: false
-    auto-reconnect: true
 
 
 GUI:


### PR DESCRIPTION
Fixes #1 

- Using connection pools should improve performance when multiple players connect or disconnect at the same time.
- Using try with resources ensures the connection is automatically closed after the query is executed.
- No need for any auto re-connect logic this way.